### PR TITLE
Remove warnings of unused imports

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -6,10 +6,16 @@ object ScalaCheckGen extends TestGen {
 
   def generate(basename: String, pkg: Option[String], parsedList: Seq[ParsedDoctest]): String = {
     val pkgLine = pkg.fold("")(p => s"package $p")
+    val importProp =
+      if (TestGen.containsExample(parsedList) || TestGen.containsProperty(parsedList))
+        "import org.scalacheck.Prop._"
+      else
+        ""
+
     s"""$pkgLine
        |
-       |import org.scalacheck.Arbitrary._
-       |import org.scalacheck.Prop._
+       |${TestGen.importArbitrary(parsedList)}
+       |$importProp
        |
        |object ${basename}Doctest
        |    extends org.scalacheck.Properties("${escape(basename)}.scala") {

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -12,8 +12,7 @@ object ScalaTestGen extends TestGen {
     val pkgLine = pkg.fold("")(p => s"package $p")
     s"""$pkgLine
        |
-       |import org.scalacheck.Arbitrary._
-       |import org.scalacheck.Prop._
+       |${TestGen.importArbitrary(parsedList)}
        |
        |class ${basename}Doctest
        |    extends $st.FunSpec

--- a/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
@@ -10,8 +10,7 @@ object Specs2TestGen extends TestGen {
     val pkgLine = pkg.fold("")(p => s"package $p")
     s"""$pkgLine
        |
-       |import org.scalacheck.Arbitrary._
-       |import org.scalacheck.Prop._
+       |${TestGen.importArbitrary(examples)}
        |
        |class ${basename}Doctest
        |    extends org.specs2.mutable.Specification

--- a/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
@@ -17,4 +17,19 @@ object TestGen {
       |  val s = scala.runtime.ScalaRunTime.replStringOf(any, 1000).init
       |  if (s.headOption == Some('\n')) s.tail else s
       |}""".stripMargin
+
+  def importArbitrary(examples: Seq[ParsedDoctest]): String =
+    if (containsProperty(examples)) "import org.scalacheck.Arbitrary._" else ""
+
+  def containsExample(examples: Seq[ParsedDoctest]): Boolean =
+    examples.exists(_.components.exists {
+      case _: Example => true
+      case _ => false
+    })
+
+  def containsProperty(examples: Seq[ParsedDoctest]): Boolean =
+    examples.exists(_.components.exists {
+      case _: Property => true
+      case _ => false
+    })
 }

--- a/src/sbt-test/sbt-doctest/simple/build.sbt
+++ b/src/sbt-test/sbt-doctest/simple/build.sbt
@@ -3,3 +3,13 @@ doctestSettings
 scalaVersion := "2.10.4"
 
 crossScalaVersions := "2.10.4" :: "2.11.2" :: Nil
+
+scalacOptions += "-Xfatal-warnings"
+scalacOptions += {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 11 =>
+      "-Ywarn-unused-import"
+    case _ =>
+      ""
+  }
+}


### PR DESCRIPTION
This is a quick and dirty demonstration of how #56 can be fixed. Without the changes to the test generators the scripted tests will fail due to the change in src/sbt-test/sbt-doctest/simple/build.sbt.

Please do not merge yet, I need to clean it up before.