### PR TITLE
Use latest Scala and sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val root = (project in file(".")).settings(
     url("https://github.com/tkawachi/sbt-doctest/"),
     "scm:git:github.com:tkawachi/sbt-doctest.git"
   )),
-  scalaVersion := "2.10.4",
+  scalaVersion := "2.10.6",
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",

--- a/lock.sbt
+++ b/lock.sbt
@@ -9,9 +9,9 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.json4s" % "json4s-ast_2.10" % "3.2.10",
   "org.json4s" % "json4s-core_2.10" % "3.2.10",
   "org.json4s" % "json4s-native_2.10" % "3.2.10",
-  "org.scala-lang" % "scala-compiler" % "2.10.4",
-  "org.scala-lang" % "scala-library" % "2.10.4",
-  "org.scala-lang" % "scala-reflect" % "2.10.4",
+  "org.scala-lang" % "scala-compiler" % "2.10.6",
+  "org.scala-lang" % "scala-library" % "2.10.6",
+  "org.scala-lang" % "scala-reflect" % "2.10.6",
   "org.scala-lang" % "scalap" % "2.10.0",
   "org.scala-sbt" % "actions" % "0.13.7",
   "org.scala-sbt" % "api" % "0.13.7",
@@ -61,4 +61,4 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.spire-math" % "jawn-parser_2.10" % "0.6.0",
   "org.spire-math" % "json4s-support_2.10" % "0.6.0"
 )
-// LIBRARY_DEPENDENCIES_HASH d6bf3180f39acceaf1557c3f50fd864ba6e87afc
+// LIBRARY_DEPENDENCIES_HASH d02f44de61c0dee8af2dee71f9dec9ddd5e4c656

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/src/sbt-test/sbt-doctest/simple/build.sbt
+++ b/src/sbt-test/sbt-doctest/simple/build.sbt
@@ -1,8 +1,8 @@
 doctestSettings
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.6"
 
-crossScalaVersions := "2.10.4" :: "2.11.2" :: Nil
+crossScalaVersions := "2.10.6" :: "2.11.7" :: Nil
 
 scalacOptions += "-Xfatal-warnings"
 scalacOptions += {

--- a/src/sbt-test/sbt-doctest/without-libs/build.sbt
+++ b/src/sbt-test/sbt-doctest/without-libs/build.sbt
@@ -3,7 +3,7 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.11.5" % "test"
 )
 
-crossScalaVersions := "2.11.2" :: "2.10.4" :: Nil
+crossScalaVersions := "2.11.7" :: "2.10.6" :: Nil
 
 doctestWithDependencies := false
 


### PR DESCRIPTION
There is no particular reason for this other than just using the latest Scala and sbt versions.