### PR TITLE
Decode `&lt;` HTML entities

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
@@ -134,7 +134,7 @@ object CommentParser extends PythonStyleParser with ReplStyleParser with Propert
 
   val allLines = (components ^^ Some.apply | anyLine ^^^ None).* <~ anyStr ^^ (_.flatten)
 
-  def parse(input: String) = parseAll(allLines, input)
+  def parse(input: String) = parseAll(allLines, input.replace("&lt;", "<"))
 
   def apply(comment: ScaladocComment): Either[String, ParsedDoctest] =
     parse(comment.text) match {

--- a/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
@@ -137,6 +137,16 @@ class CommentParserSpec extends FunSpec with Matchers {
         """.stripMargin
       parse(comment).get should equal(List(Verbatim(s"val xs = List(${LS}1,${LS}2,${LS}3)")))
     }
+
+    it("decodes `&lt;` HTML entities") {
+      val comment =
+        """ * >>> "&lt;html>&lt;/html>"
+          | * &lt;html>&lt;/html>
+        """.stripMargin
+      parse(comment).get should equal(
+        List(Example("\"<html></html>\"", TestResult("<html></html>", None), 1))
+      )
+    }
   }
 
   describe("Scala repl style") {
@@ -326,6 +336,18 @@ class CommentParserSpec extends FunSpec with Matchers {
           Example("value + 1", TestResult("2", Some("Int")), 2))
       )
     }
+
+    it("decodes &lt; HTML entities") {
+      val comment =
+        """ * scala> "&lt;html>&lt;/html>"
+        | * res0: String =
+        | * &lt;html>&lt;/html>
+      """.stripMargin
+      parse(comment).get should equal(
+        List(Example("\"<html></html>\"", TestResult("<html></html>", Some("String")), 1))
+      )
+    }
+
   }
 
   describe("Property based") {
@@ -376,6 +398,13 @@ class CommentParserSpec extends FunSpec with Matchers {
           | *     | x = 1
         """.stripMargin
       parse(comment).get should equal(List(Verbatim(s"def${LS}x = 1")))
+    }
+
+    it("decodes &lt; HTML entities") {
+      val comment =
+        """ * prop> var html = "&lt;html>&lt;/html>"
+        """.stripMargin
+      parse(comment).get should equal(List(Verbatim("var html = \"<html></html>\"")))
     }
   }
 


### PR DESCRIPTION
Due to parsing restrictions in Scaladoc(/Javadoc?) when documenting code that uses HTML or XML you often need to encode tag opening angle brackets (`<`) as `&lt;` so that it is not parsed as HTML elements in the browser and not displayed. For example:

```
/**
 * Documentation for the Microtesia microdata parsing library.
 *
 * == Usage ==
 *
 * To use simply put the Microtesia API in scope and call the [[parseMicrodata]]
 * function as follows:
 *
 * {{{
 * scala> import microtesia._
 * import microtesia.
 * 
 * scala> import scala.util.Try
 * import scala.util.Try
 *
 * scala> parseMicrodata("""&lt;div itemscope itemtype="http://schema.org/Movie"><h1 itemprop="name">Avatar</h1></div>""")
 * res0: Try[microtesia.MicrodataDocument] = Success(MicrodataDocument(List(MicrodataItem(ArrayBuffer((name,MicrodataString(Avatar))),Some(http://schema.org/Movie),None))))
 * }}}
 */
```

However, sbt-doctest parses the text differently causing test failures unless you rewrite `&lt;` as `<`, which in-turn causes browser display problems.

This commit gives the best of both worlds by turning all occurrences of `&lt;` back into `<` for the purposes of the doctests only.