### PR TITLE
Optionally decode HTML entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ Please use `<BLANKLINE>` when an output contains blank lines.
  */
 def helloWorld = "Hello\n\nWorld"
 ```
+## HTML Entities
+
+Often when documenting libraries that work with HTML you need to encode HTML entities so that they will be displayed in browsers.
+
+However, `sbt-doctest` ignores these and attempts to compare encoded HTML with unencoded HTML entities. You can fix this by enabling decoding of HTML entities. Just add the following setting to your `build.sbt`:
+
+```
+doctestDecodeHtmlEntities := true
+```
+
+Now the following should pass:
+
+```scala
+  /**
+   * {{{
+   * >>> Main.html
+   * &lt;html&gt;&lt;/html&gt;
+   * }}}
+   */
+  val html = "<html></html>"
+```
 
 ## License
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,11 @@ lazy val root = (project in file(".")).settings(
     "specs2Version" -> "2.4.15"
   ),
   libraryDependencies ++= Seq(
-    "org.scala-lang" %  "scala-compiler" % scalaVersion.value,
-    "org.scalatest"  %% "scalatest"      % scalatestVersion % "test",
-    "org.scalacheck" %% "scalacheck"     % scalacheckVersion % "test",
-    "commons-io"     %  "commons-io"     % "2.4"
+    "org.scala-lang"     %  "scala-compiler" % scalaVersion.value,
+    "org.scalatest"      %% "scalatest"      % scalatestVersion % "test",
+    "org.scalacheck"     %% "scalacheck"     % scalacheckVersion % "test",
+    "commons-io"         %  "commons-io"     % "2.4",
+    "org.apache.commons" %  "commons-lang3"  % "3.4"
   ),
   doctestTestFramework := DoctestTestFramework.ScalaTest
 ).settings(scalariformSettings: _*)

--- a/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
@@ -40,6 +40,7 @@ object DoctestPlugin extends AutoPlugin {
     val doctestTestFramework = settingKey[DoctestTestFramework]("Test framework. Specify ScalaCheck (default), Specs2 or ScalaTest.")
     val doctestWithDependencies = settingKey[Boolean]("Whether to include libraryDependencies to doctestSettings.")
     val doctestGenTests = taskKey[Seq[File]]("Generates test files.")
+    val doctestDecodeHtmlEntities = settingKey[Boolean]("Whether to decode HTML entities.")
 
     val DoctestTestFramework = self.DoctestTestFramework
   }
@@ -64,6 +65,7 @@ object DoctestPlugin extends AutoPlugin {
   val doctestGenSettings = Seq(
     doctestTestFramework := (doctestTestFramework ?? ScalaCheck).value,
     doctestWithDependencies := (doctestWithDependencies ?? true).value,
+    doctestDecodeHtmlEntities := (doctestDecodeHtmlEntities ?? false).value,
     doctestGenTests := {
       (managedSourceDirectories in Test).value.headOption match {
         case None =>
@@ -73,7 +75,7 @@ object DoctestPlugin extends AutoPlugin {
           val srcEncoding = TestGenerator.findEncoding((scalacOptions in Compile).value).getOrElse("UTF-8")
           (unmanagedSources in Compile).value
             .filter(_.ext == "scala")
-            .flatMap(TestGenerator(_, srcEncoding, doctestTestFramework.value))
+            .flatMap(TestGenerator(_, srcEncoding, doctestTestFramework.value, doctestDecodeHtmlEntities.value))
             .groupBy(r => r.pkg -> r.basename)
             .flatMap {
               case ((pkg, basename), results) =>

--- a/src/main/scala/com/github/tkawachi/doctest/TestGenerator.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestGenerator.scala
@@ -4,6 +4,7 @@ import java.io.File
 import DoctestPlugin.DoctestTestFramework
 import scala.io.Source
 import org.apache.commons.io.FilenameUtils
+import org.apache.commons.lang3.StringEscapeUtils.unescapeHtml4
 
 object TestGenerator {
   case class Result(pkg: Option[String], basename: String, testSource: String)
@@ -16,13 +17,19 @@ object TestGenerator {
     case DoctestTestFramework.ScalaCheck => ScalaCheckGen
   }
 
+  private def decodeHtml(comment: ScaladocComment) = comment.copy(text = unescapeHtml4(comment.text))
+
   /**
    * Generates test source code from scala source file.
    */
-  def apply(srcFile: File, srcEncoding: String, framework: DoctestTestFramework): Seq[Result] = {
+  def apply(srcFile: File, srcEncoding: String, framework: DoctestTestFramework, decodeHtmlEnabled: Boolean): Seq[Result] = {
     val src = Source.fromFile(srcFile, srcEncoding).mkString
     val basename = FilenameUtils.getBaseName(srcFile.getName)
     extractor.extract(src)
+      .map { comment =>
+        if (decodeHtmlEnabled) decodeHtml(comment)
+        else comment
+      }
       .flatMap(comment => CommentParser(comment).right.toOption.filter(_.components.size > 0))
       .groupBy(_.pkg).map {
         case (pkg, examples) =>

--- a/src/sbt-test/sbt-doctest/html-entities/build.sbt
+++ b/src/sbt-test/sbt-doctest/html-entities/build.sbt
@@ -1,0 +1,15 @@
+scalaVersion := "2.10.6"
+
+crossScalaVersions := "2.10.6" :: "2.11.7" :: Nil
+
+scalacOptions += "-Xfatal-warnings"
+scalacOptions += {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 11 =>
+      "-Ywarn-unused-import"
+    case _ =>
+      ""
+  }
+}
+
+doctestDecodeHtmlEntities := true

--- a/src/sbt-test/sbt-doctest/html-entities/project/plugins.sbt
+++ b/src/sbt-test/sbt-doctest/html-entities/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % System.getProperty("plugin.version"))

--- a/src/sbt-test/sbt-doctest/html-entities/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-doctest/html-entities/src/main/scala/Main.scala
@@ -1,0 +1,13 @@
+package sbt_doctest
+
+object Main {
+
+  /**
+   * {{{
+   * >>> Main.html
+   * &lt;html&gt;&lt;/html&gt;
+   * }}}
+   */
+  val html = "<html></html>"
+
+}

--- a/src/sbt-test/sbt-doctest/html-entities/test
+++ b/src/sbt-test/sbt-doctest/html-entities/test
@@ -1,0 +1,16 @@
+> set doctestTestFramework := DoctestTestFramework.ScalaTest
+> + test:managedSources
+$ exists target/scala-2.10/src_managed/test/sbt_doctest/MainDoctest.scala
+$ exists target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
+> + test:compile
+> + test
+
+# Try with specs2
+> set doctestTestFramework := DoctestTestFramework.Specs2
+> clean
+> + test
+
+# Try with scalacheck
+> set doctestTestFramework := DoctestTestFramework.ScalaCheck
+> clean
+> + test

--- a/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-doctest/simple/src/main/scala/Main.scala
@@ -122,4 +122,13 @@ object Main {
    * }}}
    */
   val helloWorld = "Hello\n\nWorld"
+
+  /**
+   * {{{
+   * >>> Main.html
+   * &lt;html&gt;&lt;/html&gt;
+   * }}}
+   */
+  val html = "&lt;html&gt;&lt;/html&gt;"
+
 }


### PR DESCRIPTION
Due to parsing restrictions in Scaladoc(/Javadoc?) when documenting code that uses HTML or XML you often need to encode tag angle brackets (e.g.`<` as `&lt;)` so that it is not parsed as HTML elements by the browser and hidden.

However, sbt-doctest parses the text as-is causing test failures unless you rewrite `&lt;` as `<`, which in-turn causes browser display problems (back to problem one).

This commit gives the best of both worlds by creating an optional SBT setting that decodes HTML entities in the doctests only.

Safer version of #63 