### PR TITLE
Add optional support for Markdown code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Now the following should pass:
   val html = "<html></html>"
 ```
 
+## Markdown
+
+Also supports code examples in Markdown documentation. To enable add the following to your `build.bst`:
+
+```
+doctestMarkdownCompiler := true
+```
+
+Any code blocks that start with the ````scala` markdown directive will be parsed.
+
 ## License
 
 MIT

--- a/src/main/scala/com/github/tkawachi/doctest/MarkdownCodeblock.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MarkdownCodeblock.scala
@@ -1,0 +1,3 @@
+package com.github.tkawachi.doctest
+
+case class MarkdownCodeblock(text: String, lineNo: Int)

--- a/src/main/scala/com/github/tkawachi/doctest/MarkdownCodeblocksExtractor.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MarkdownCodeblocksExtractor.scala
@@ -1,0 +1,21 @@
+package com.github.tkawachi.doctest
+
+import scala.util.matching.Regex
+
+class MarkdownCodeblocksExtractor {
+
+  private val regex = """(?ms)^```scala(.*?)```""".r
+
+  def extract(source: String): Seq[MarkdownCodeblock] = {
+    val blocks =
+      for {
+        code <- regex.findAllMatchIn(source)
+      } yield MarkdownCodeblock(code.toString, line(source, code))
+
+    blocks.toSeq
+  }
+
+  private def line(source: String, m: Regex.Match): Int =
+    source.substring(m.start).split("\r\n|\r|\n").length
+
+}

--- a/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
@@ -1,0 +1,23 @@
+package com.github.tkawachi.doctest
+
+import java.io.File
+import scala.io.Source
+import org.apache.commons.io.FilenameUtils
+import com.github.tkawachi.doctest.DoctestPlugin.DoctestTestFramework
+
+object MarkdownTestGenerator {
+
+  val extractor = new MarkdownCodeblocksExtractor
+
+  def apply(source: File, framework: DoctestTestFramework): Seq[TestSource] = {
+    val contents = Source.fromFile(source).mkString
+    val basename = FilenameUtils.getBaseName(source.getName)
+    extractor.extract(contents)
+      .flatMap(codeblock => CodeblockParser(codeblock).right.toOption.filter(_.components.size > 0))
+      .groupBy(_.pkg).map {
+        case (pkg, examples) => TestSource(pkg, basename, testGen(framework).generate(basename, pkg, examples))
+      }
+      .toSeq
+  }
+
+}

--- a/src/main/scala/com/github/tkawachi/doctest/ScaladocExtractor.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScaladocExtractor.scala
@@ -6,7 +6,7 @@ import java.io.File
 /**
  * Extract examples from scala source.
  */
-class Extractor {
+class ScaladocExtractor {
 
   private val settings = new Settings(Console println _)
   settings.bootclasspath.value = ScalaPath.pathList.mkString(File.pathSeparator)

--- a/src/main/scala/com/github/tkawachi/doctest/TestSource.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestSource.scala
@@ -1,0 +1,3 @@
+package com.github.tkawachi.doctest
+
+case class TestSource(pkg: Option[String], basename: String, testSource: String)

--- a/src/main/scala/com/github/tkawachi/doctest/package.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/package.scala
@@ -1,0 +1,13 @@
+package com.github.tkawachi
+
+import com.github.tkawachi.doctest.DoctestPlugin.DoctestTestFramework
+
+package object doctest {
+
+  val testGen: Map[DoctestTestFramework, TestGen] = Map(
+    DoctestTestFramework.ScalaTest -> ScalaTestGen,
+    DoctestTestFramework.Specs2 -> Specs2TestGen,
+    DoctestTestFramework.ScalaCheck -> ScalaCheckGen
+  )
+
+}

--- a/src/sbt-test/sbt-doctest/simple/README.md
+++ b/src/sbt-test/sbt-doctest/simple/README.md
@@ -1,0 +1,9 @@
+# Markdown Compiler Test
+
+```scala
+scala> import sbt_doctest.Main.abc
+import sbt_doctest.Main.abc
+
+scala> abc
+res0: String = Hello, world!
+```

--- a/src/sbt-test/sbt-doctest/simple/build.sbt
+++ b/src/sbt-test/sbt-doctest/simple/build.sbt
@@ -11,3 +11,5 @@ scalacOptions += {
       ""
   }
 }
+
+doctestMarkdownCompiler := true

--- a/src/sbt-test/sbt-doctest/simple/test
+++ b/src/sbt-test/sbt-doctest/simple/test
@@ -6,6 +6,8 @@ $ absent target/scala-2.10/src_managed/test/sbt_doctest/NoDoctestDoctest.scala
 $ absent target/scala-2.11/src_managed/test/sbt_doctest/NoDoctestDoctest.scala
 $ exists target/scala-2.10/src_managed/test/sbt_doctest/VerbatimTestDoctest.scala
 $ exists target/scala-2.11/src_managed/test/sbt_doctest/VerbatimTestDoctest.scala
+$ exists target/scala-2.10/src_managed/test/READMEDoctest.scala
+$ exists target/scala-2.11/src_managed/test/READMEDoctest.scala
 > + test:compile
 > + test
 

--- a/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
@@ -389,4 +389,52 @@ class CommentParserSpec extends FunSpec with Matchers {
       parse(comment).get should equal(List.empty)
     }
   }
+
+  describe("Markdown comments") {
+    it("python style") {
+      val comment =
+        """```scala
+          |>>> 1 + 2
+          |3
+          |```
+        """.stripMargin
+      parse(comment).get should equal(List(Example("1 + 2", TestResult("3"), 2)))
+    }
+
+    it("repl style") {
+      val comment =
+        """```scala
+          |scala> 1 + 2
+          |res0: Int = 3
+          |```
+        """.stripMargin
+      parse(comment).get should equal(List(Example("1 + 2", TestResult("3", Some("Int")), 2)))
+    }
+
+    it("repl style with import and example") {
+      val comment =
+        """```scala
+          |scala> import scala.util.Success
+          |import scala.util.Success
+          |
+          |scala> Success(1 + 2)
+          |res0: scala.util.Try[Int] = Success(3)
+          |```
+        """.stripMargin
+      parse(comment).get should equal(List(
+        Verbatim("import scala.util.Success"),
+        Example("Success(1 + 2)", TestResult("Success(3)", Some("scala.util.Try[Int]")), 5)
+      ))
+    }
+
+    it("property style") {
+      val comment =
+
+        """```scala
+          |prop> (i: Int) => i + i == i * 2
+          |```
+        """.stripMargin
+      parse(comment).get should equal(List(Property("""(i: Int) => i + i == i * 2""", 2)))
+    }
+  }
 }

--- a/src/test/scala/com/github/tkawachi/doctest/MarkdownCodeblocksExtractorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/MarkdownCodeblocksExtractorSpec.scala
@@ -1,0 +1,45 @@
+package com.github.tkawachi.doctest
+
+import org.scalatest.{ BeforeAndAfter, Matchers, FunSpec }
+import scala.io.Source
+
+class MarkdownCodeblocksExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
+
+  val extractor = new MarkdownCodeblocksExtractor
+
+  it("extracts Markdown code block") {
+    val src = """
+              | # Header
+              |
+              |```scala
+              | scala> println("Hello, World!")
+              | Hello, World!
+              | ```""".stripMargin
+
+    extractor.extract(src) should contain(
+      MarkdownCodeblock(
+        """```scala
+         | scala> println("Hello, World!")
+         | Hello, World!
+         | ```""".stripMargin, 4
+      )
+    )
+  }
+
+  it("extracts multiple Markdown code blocks") {
+    val src = """
+              | # Header
+              |
+              |```scala
+              | scala> println("Hello, World!")
+              | Hello, World!
+              | ```
+              |
+              |```scala
+              | scala> println("Good night, World!")
+              | Good night, World!
+              | ```""".stripMargin
+
+    extractor.extract(src).size should equal(2)
+  }
+}

--- a/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
@@ -3,9 +3,9 @@ package com.github.tkawachi.doctest
 import org.scalatest.{ BeforeAndAfter, Matchers, FunSpec }
 import scala.io.Source
 
-class ExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
+class ScaladocExtractorSpec extends FunSpec with Matchers with BeforeAndAfter {
 
-  val extractor = new Extractor
+  val extractor = new ScaladocExtractor
 
   it("extracts from Test.scala") {
     val src = Source.fromFile("src/test/resources/Test.scala").mkString


### PR DESCRIPTION
Added support for Markdown documentation code examples. This feature is optional and is enabled using the `doctestMarkdownCompiler` flag. Includes documentation and tests.

This closes:

https://github.com/tkawachi/sbt-doctest/issues/62