### PR TITLE
Minor doc change to make sure people dont trip over when using specs2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ libraryDependencies ++= Seq(
 )
 ```
 
+*Note*:
+If you are using [Specs2](http://etorreborre.github.io/specs2/) with Scalac `2.11.8`, you need to include both `specs2-core` & `specs2-scalacheck`. Otherwise, `sbt test` would complain with an error message:
+> type ScalaCheck is not a member of package org.specs2
+>
+
 ## Usage
 
 sbt-doctest will generate tests from


### PR DESCRIPTION
Nice plugin. Thought of alerting new users of this plugin to be careful when using Specs2 and Scalac 2.11.8