### PR TITLE
Remove scalacheck dependency when not necessary (#71)

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -17,7 +17,7 @@ object ScalaTestGen extends TestGen {
        |class ${basename}Doctest
        |    extends $st.FunSpec
        |    with $st.Matchers
-       |    with $st.prop.Checkers {
+       |    ${TestGen.withCheckers(parsedList)} {
        |
        |${StringUtil.indent(TestGen.helperMethods, "  ")}
        |

--- a/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
@@ -21,6 +21,9 @@ object TestGen {
   def importArbitrary(examples: Seq[ParsedDoctest]): String =
     if (containsProperty(examples)) "import org.scalacheck.Arbitrary._" else ""
 
+  def withCheckers(examples: Seq[ParsedDoctest]): String =
+    if (containsProperty(examples)) "with org.scalatest.prop.Checkers" else ""
+
   def containsExample(examples: Seq[ParsedDoctest]): Boolean =
     examples.exists(_.components.exists {
       case _: Example => true


### PR DESCRIPTION
This PR simply removes `with org.scalatest.props.Checkers` from ScalaTest test suites when no example uses property-based tests.

This appears to fix #71 without any regression that I could spot.

The only slightly dodgy bit is that `TestGen.withCheckers` doesn't rely on `ScalaTestGen.st`. I'm happy to fix that if necessary, but would like to know how you'd like me to go about it.