### PR TITLE
Update checkers extension for Scalatest

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
@@ -22,7 +22,7 @@ object TestGen {
     if (containsProperty(examples)) "import org.scalacheck.Arbitrary._" else ""
 
   def withCheckers(examples: Seq[ParsedDoctest]): String =
-    if (containsProperty(examples)) "with org.scalatest.prop.Checkers" else ""
+    if (containsProperty(examples)) "with org.scalatest.check.Checkers" else ""
 
   def containsExample(examples: Seq[ParsedDoctest]): Boolean =
     examples.exists(_.components.exists {


### PR DESCRIPTION
As of ScalaTest 3.1.0, org.scalatest.prop.Checkers has been
deprecated. Moving forward only org.scalatest.check.Checkers will
be supported.

Reference: [Scalatest code](https://github.com/scalatest/scalatest/blob/2f72123d99a521d8702ea1b3090b205897b8790d/scalatest/src/main/scala/org/scalatest/prop/package.scala#L28-L29)