### PR TITLE
Bump uTest to 0.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ doctestTestFramework := DoctestTestFramework.Specs2
 If you are using ``µTest``, add the following lines to your ``build.sbt``:
 ```scala
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %% "utest" % "0.4.7" % "test"
+  "com.lihaoyi" %% "utest" % "0.4.8" % "test"
 )
 
 doctestTestFramework := DoctestTestFramework.MicroTest
@@ -75,7 +75,7 @@ shown in the example below which uses ``uTest`` with property checks, which requ
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.lihaoyi"    %% "utest"      % "0.4.7"  % "test",
+  "com.lihaoyi"    %% "utest"      % "0.4.8"  % "test",
   "org.scalatest"  %% "scalatest"  % "3.0.1"  % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val versions = new {
   val ScalaTest  = "3.0.1"
   val ScalaCheck = "1.13.4"
   val Specs2     = "3.8.7"
-  val utest      = "0.4.7"
+  val utest      = "0.4.8"
   val CommonsIO  = "2.4"
   val Lang3      = "3.4"
 }

--- a/lock.sbt
+++ b/lock.sbt
@@ -3,7 +3,7 @@
 // https://github.com/tkawachi/sbt-lock/
 dependencyOverrides in ThisBuild ++= Set(
   "com.jcraft" % "jsch" % "0.1.50",
-  "com.lihaoyi" % "utest_2.10" % "0.4.7",
+  "com.lihaoyi" % "utest_2.10" % "0.4.8",
   "com.thoughtworks.paranamer" % "paranamer" % "2.6",
   "commons-io" % "commons-io" % "2.4",
   "jline" % "jline" % "2.14.3",
@@ -67,4 +67,4 @@ dependencyOverrides in ThisBuild ++= Set(
   "org.spire-math" % "jawn-parser_2.10" % "0.6.0",
   "org.spire-math" % "json4s-support_2.10" % "0.6.0"
 )
-// LIBRARY_DEPENDENCIES_HASH a82e41f63203af576724e23e641e6ea34e8d06fc
+// LIBRARY_DEPENDENCIES_HASH 56ba80d8c3ed3b4c8a577ff43e495c5a6172becd

--- a/src/sbt-test/sbt-doctest/html-entities/build.sbt
+++ b/src/sbt-test/sbt-doctest/html-entities/build.sbt
@@ -18,7 +18,7 @@ scalacOptions        ++= (scalaVersion.value match {
 
 // Declares scalatest, scalacheck and utest dependencies explicitly.
 libraryDependencies ++= Seq(
-  "com.lihaoyi"    %% "utest"             % "0.4.7"  % "test",
+  "com.lihaoyi"    %% "utest"             % "0.4.8"  % "test",
   "org.scalatest"  %% "scalatest"         % "3.0.1"  % "test",
   "org.scalacheck" %% "scalacheck"        % "1.13.4" % "test",
   "org.specs2"     %% "specs2-core"       % "3.8.7"  % "test",

--- a/src/sbt-test/sbt-doctest/simple/build.sbt
+++ b/src/sbt-test/sbt-doctest/simple/build.sbt
@@ -22,7 +22,7 @@ scalacOptions        ++= (scalaVersion.value match {
 
 // Declares scalatest, scalacheck and utest dependencies explicitly.
 libraryDependencies ++= Seq(
-  "com.lihaoyi"    %% "utest"             % "0.4.7"  % "test",
+  "com.lihaoyi"    %% "utest"             % "0.4.8"  % "test",
   "org.scalatest"  %% "scalatest"         % "3.0.1"  % "test",
   "org.scalacheck" %% "scalacheck"        % "1.13.4" % "test",
   "org.specs2"     %% "specs2-core"       % "3.8.7"  % "test",


### PR DESCRIPTION
uTest 0.4.8 supports Scala Native 0.3.1 projects.

Could you please advise whether or not ``sbt-doctest`` could be employed in Scala Native projects?