### PR TITLE
Use fully qualified names in generated code

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
@@ -11,7 +11,7 @@ object MicroTestGen extends TestGen {
     val pkgLine = pkg.fold("")(p => s"package $p")
     s"""$pkgLine
        |
-       |import utest._
+       |import _root_.utest._
        |
        |object ${basename}Doctest extends TestSuite {
        |

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -8,7 +8,7 @@ object ScalaCheckGen extends TestGen {
     val pkgLine = pkg.fold("")(p => s"package $p")
     val importProp =
       if (TestGen.containsExample(parsedList) || TestGen.containsProperty(parsedList))
-        "import org.scalacheck.Prop._"
+        "import _root_.org.scalacheck.Prop._"
       else
         ""
 
@@ -18,7 +18,7 @@ object ScalaCheckGen extends TestGen {
        |$importProp
        |
        |object ${basename}Doctest
-       |    extends org.scalacheck.Properties("${escape(basename)}.scala") {
+       |    extends _root_.org.scalacheck.Properties("${escape(basename)}.scala") {
        |
        |${StringUtil.indent(TestGen.helperMethods, "  ")}
        |
@@ -28,7 +28,7 @@ object ScalaCheckGen extends TestGen {
   }
 
   def generateExample(basename: String, parsed: ParsedDoctest): String =
-    s"""  include(new org.scalacheck.Properties("${parsed.symbol}") {
+    s"""  include(new _root_.org.scalacheck.Properties("${parsed.symbol}") {
        |${parsed.components.map(gen(parsed.lineNo, _)).mkString("\n\n")}
        |  })""".stripMargin
 
@@ -37,14 +37,14 @@ object ScalaCheckGen extends TestGen {
     component match {
       case Example(expr, expected, _) =>
         val typeTest = expected.tpe.fold("")(tpe => genTypeTest(expr, tpe))
-        s"""    property("$description") = org.scalacheck.Prop.secure {$typeTest
+        s"""    property("$description") = _root_.org.scalacheck.Prop.secure {$typeTest
            |      val actual = sbtDoctestReplString($expr)
            |      val expected = "${escape(expected.value)}"
            |      (actual == expected) :| s"'$$actual' is not equal to '$$expected'"
            |    }""".stripMargin
 
       case Property(prop, _) =>
-        s"""    property("$description") = org.scalacheck.Prop.forAll {
+        s"""    property("$description") = _root_.org.scalacheck.Prop.forAll {
            |      $prop
            |    }""".stripMargin
 

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTest30Gen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTest30Gen.scala
@@ -4,5 +4,5 @@ package com.github.tkawachi.doctest
  * Test generator for ScalaTest < 3.1.0.
  */
 class ScalaTest30Gen extends ScalaTestGen {
-  override protected def withCheckersString: String = "with org.scalatest.prop.Checkers"
+  override protected def withCheckersString: String = "with _root_.org.scalatest.prop.Checkers"
 }

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTest31Gen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTest31Gen.scala
@@ -4,5 +4,5 @@ package com.github.tkawachi.doctest
  * Test generator for ScalaTest >= 3.1.0.
  */
 class ScalaTest31Gen extends ScalaTestGen {
-  override protected def withCheckersString: String = "with org.scalatest.check.Checkers"
+  override protected def withCheckersString: String = "with _root_.org.scalatest.check.Checkers"
 }

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -12,7 +12,7 @@ import scala.util.Try
  */
 trait ScalaTestGen extends TestGen {
 
-  private val st = "org.scalatest"
+  private val st = "_root_.org.scalatest"
 
   def generate(basename: String, pkg: Option[String], parsedList: Seq[ParsedDoctest]): String = {
     val pkgLine = pkg.fold("")(p => s"package $p")

--- a/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
@@ -13,8 +13,8 @@ object Specs2TestGen extends TestGen {
        |${TestGen.importArbitrary(examples)}
        |
        |class ${basename}Doctest
-       |    extends org.specs2.mutable.Specification
-       |    with org.specs2.ScalaCheck {
+       |    extends _root_.org.specs2.mutable.Specification
+       |    with _root_.org.specs2.ScalaCheck {
        |
        |${StringUtil.indent(TestGen.helperMethods, "  ")}
        |

--- a/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/TestGen.scala
@@ -12,14 +12,14 @@ object TestGen {
    * Helper methods which will be embedded in generated tests.
    */
   val helperMethods =
-    """def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): Unit = ()
-      |def sbtDoctestReplString(any: Any): String = {
-      |  val s = scala.runtime.ScalaRunTime.replStringOf(any, 1000).init
+    """def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = ()
+      |def sbtDoctestReplString(any: _root_.scala.Any): _root_.scala.Predef.String = {
+      |  val s = _root_.scala.runtime.ScalaRunTime.replStringOf(any, 1000).init
       |  if (s.headOption == Some('\n')) s.tail else s
       |}""".stripMargin
 
   def importArbitrary(examples: Seq[ParsedDoctest]): String =
-    if (containsProperty(examples)) "import org.scalacheck.Arbitrary._" else ""
+    if (containsProperty(examples)) "import _root_.org.scalacheck.Arbitrary._" else ""
 
   def containsExample(examples: Seq[ParsedDoctest]): Boolean =
     examples.exists(_.components.exists {

--- a/src/sbt-test/sbt-doctest/scalatest31/test
+++ b/src/sbt-test/sbt-doctest/scalatest31/test
@@ -4,5 +4,5 @@
 
 $ exists target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
 $ exists target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala
-> existsInFile "with org.scalatest.check.Checkers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
-> existsInFile "with org.scalatest.check.Checkers" target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala
+> existsInFile "with _root_.org.scalatest.check.Checkers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
+> existsInFile "with _root_.org.scalatest.check.Checkers" target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala

--- a/src/sbt-test/sbt-doctest/simple/test
+++ b/src/sbt-test/sbt-doctest/simple/test
@@ -22,7 +22,7 @@ $ exists target/scala-2.12/src_managed/test/READMEDoctest.scala
 > clean
 > set doctestTestFramework := DoctestTestFramework.ScalaTest
 > + test
-> existsInFile "with org.scalatest.prop.Checkers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
+> existsInFile "with _root_.org.scalatest.prop.Checkers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
 
 # Try with specs2
 > reload


### PR DESCRIPTION
This prevents clashes with names that are defined in projects
that use sbt-doctest. A recent example of a name clash has been
observed in the libra project (https://github.com/to-ithaca/libra/issues/43)
where our use of `Unit` (which we assumed to be `_root_.scala.Unit`)
clashed with the library defined `libra.Unit` type.