### PR TITLE
Fix markdown rendering in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Also supports code examples in Markdown documentation. To enable add the followi
 doctestMarkdownEnabled := true
 ```
 
-Any code blocks that start with the ````scala` markdown directive will be parsed.
+Any code blocks that start with the ```` ```scala```` markdown directive will be parsed.
 It searches `*.md` under `baseDirectory` by default. It can be configured by
 `doctestMarkdownPathFinder`.
 


### PR DESCRIPTION
Currently there's a part of the readme that looks like this:

Any code blocks that start with the ````scala` markdown directive will be parsed.
It searches `*.md` under `baseDirectory` by default. It can be configured by
`doctestMarkdownPathFinder`.


The syntax is a little funky, but this PR changes it to look like this:

Any code blocks that start with the ```` ```scala```` markdown directive will be parsed.
It searches `*.md` under `baseDirectory` by default. It can be configured by
`doctestMarkdownPathFinder`.