### PR TITLE
Disambiguate markdown files

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
@@ -1,4 +1,6 @@
 package com.github.tkawachi.doctest
+import java.nio.file.Path
+
 import sbt._, Keys._
 import sbt.plugins.JvmPlugin
 import SbtCompat._
@@ -59,9 +61,16 @@ object DoctestPlugin extends AutoPlugin {
 
   private def doctestMarkdownGenTests(
                                        finder: PathFinder,
+                                       baseDirectoryPath: Path,
                                        testGen: TestGen) = {
-      finder.filter(!_.isDirectory).get
-        .flatMap(MarkdownTestGenerator(_, testGen))
+    finder
+      .filter(!_.isDirectory)
+      .get
+      .zipWithIndex
+      .flatMap{
+        case (file, disambiguatingIdx) =>
+          MarkdownTestGenerator(file, baseDirectoryPath, testGen, disambiguatingIdx.toString)
+      }
   }
 
 
@@ -91,7 +100,7 @@ object DoctestPlugin extends AutoPlugin {
 
           val pathFinder = doctestMarkdownPathFinder.value
           val markdownTests = if (doctestMarkdownEnabled.value) {
-            doctestMarkdownGenTests(pathFinder, testGen)
+            doctestMarkdownGenTests(pathFinder, baseDirectory.value.toPath, testGen)
           } else {
             Seq()
           }

--- a/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
@@ -99,8 +99,9 @@ object DoctestPlugin extends AutoPlugin {
           )
 
           val pathFinder = doctestMarkdownPathFinder.value
+          val baseDirectoryPath = baseDirectory.value.toPath
           val markdownTests = if (doctestMarkdownEnabled.value) {
-            doctestMarkdownGenTests(pathFinder, baseDirectory.value.toPath, testGen)
+            doctestMarkdownGenTests(pathFinder, baseDirectoryPath, testGen)
           } else {
             Seq()
           }

--- a/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
@@ -1,20 +1,42 @@
 package com.github.tkawachi.doctest
 
 import java.io.File
+import java.nio.file.Path
+
 import scala.io.Source
-import org.apache.commons.io.FilenameUtils
+
+import scala.annotation.tailrec
 
 object MarkdownTestGenerator {
 
   val extractor = new MarkdownCodeblocksExtractor
 
-  def apply(source: File, testGen: TestGen): Seq[TestSource] = {
+  private def getPathComponents(path: Path): List[String] = {
+    getPathComponentsRec(path, List.empty)
+  }
+
+  @tailrec
+  private def getPathComponentsRec(path: Path, componentsSoFar: List[String]): List[String] = {
+    val currentNameCount = path.getNameCount
+    val newComponents = path.getName(currentNameCount - 1).toString :: componentsSoFar
+    Option(path.getParent) match {
+      case None =>
+        newComponents
+      case Some(parentPath) =>
+        getPathComponentsRec(parentPath, newComponents)
+    }
+  }
+
+  def apply(source: File, relativeTo: Path, testGen: TestGen, disambiguatingSuffix: String): Seq[TestSource] = {
     val contents = Source.fromFile(source).mkString
-    val basename = FilenameUtils.getBaseName(source.getName)
+    val generatedClassName = getPathComponents(relativeTo.relativize(source.toPath))
+      .mkString("")
+      .filterNot(_ == '.') // This is for getting rid of periods in extensions that can mess up class names such as ".md"
+      .++(disambiguatingSuffix)
     extractor.extract(contents)
       .flatMap(codeblock => CodeblockParser(codeblock).right.toOption.filter(_.components.nonEmpty))
       .groupBy(_.pkg).map {
-        case (pkg, examples) => TestSource(pkg, basename, testGen.generate(basename, pkg, examples))
+        case (pkg, examples) => TestSource(pkg, generatedClassName, testGen.generate(generatedClassName, pkg, examples))
       }
       .toSeq
   }

--- a/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MarkdownTestGenerator.scala
@@ -30,6 +30,7 @@ object MarkdownTestGenerator {
   def apply(source: File, relativeTo: Path, testGen: TestGen, disambiguatingSuffix: String): Seq[TestSource] = {
     val contents = Source.fromFile(source).mkString
     val generatedClassName = getPathComponents(relativeTo.relativize(source.toPath))
+      .map(_.capitalize)
       .mkString("")
       .filterNot(_ == '.') // This is for getting rid of periods in extensions that can mess up class names such as ".md"
       .++(disambiguatingSuffix)

--- a/src/sbt-test/sbt-doctest/simple/test
+++ b/src/sbt-test/sbt-doctest/simple/test
@@ -8,8 +8,8 @@ $ absent target/scala-2.11/src_managed/test/sbt_doctest/NoDoctestDoctest.scala
 $ absent target/scala-2.12/src_managed/test/sbt_doctest/NoDoctestDoctest.scala
 $ exists target/scala-2.11/src_managed/test/sbt_doctest/VerbatimTestDoctest.scala
 $ exists target/scala-2.12/src_managed/test/sbt_doctest/VerbatimTestDoctest.scala
-$ exists target/scala-2.11/src_managed/test/READMEDoctest.scala
-$ exists target/scala-2.12/src_managed/test/READMEDoctest.scala
+$ exists target/scala-2.11/src_managed/test/READMEmd0Doctest.scala
+$ exists target/scala-2.12/src_managed/test/READMEmd0Doctest.scala
 
 # Try with utest
 > reload


### PR DESCRIPTION
This fixes https://github.com/tkawachi/sbt-doctest/issues/103 where
multiple markdown files of the same name could not exist in different
directories.