### PR TITLE
Support for Java String escape character '\'

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
@@ -27,7 +27,7 @@ object MicroTestGen extends TestGen {
   }
 
   def generateExample(basename: String, parsed: ParsedDoctest): String = {
-    s"""  "${escape(basename)}.scala:${parsed.lineNo}: ${parsed.symbol}"-{
+    s"""  "${escape(basename)}.scala:${parsed.lineNo}: ${escape(parsed.symbol)}"-{
        |${parsed.components.map(gen(parsed.lineNo, _)).mkString("\n\n")}
        |  }""".stripMargin
   }

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -1,6 +1,6 @@
 package com.github.tkawachi.doctest
 
-import com.github.tkawachi.doctest.StringUtil.escape
+import StringUtil.escape
 
 object ScalaCheckGen extends TestGen {
 
@@ -28,7 +28,7 @@ object ScalaCheckGen extends TestGen {
   }
 
   def generateExample(basename: String, parsed: ParsedDoctest): String =
-    s"""  include(new _root_.org.scalacheck.Properties("${parsed.symbol}") {
+    s"""  include(new _root_.org.scalacheck.Properties("${escape(parsed.symbol)}") {
        |${parsed.components.map(gen(parsed.lineNo, _)).mkString("\n\n")}
        |  })""".stripMargin
 

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -33,7 +33,7 @@ trait ScalaTestGen extends TestGen {
   }
 
   private def generateExample(basename: String, parsed: ParsedDoctest): String = {
-    s"""  describe("${escape(basename)}.scala:${parsed.lineNo}: ${parsed.symbol}") {
+    s"""  describe("${escape(basename)}.scala:${parsed.lineNo}: ${escape(parsed.symbol)}") {
        |${parsed.components.map(gen(parsed.lineNo, _)).mkString("\n\n")}
        |  }""".stripMargin
   }

--- a/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
@@ -24,7 +24,7 @@ object Specs2TestGen extends TestGen {
   }
 
   def generateExample(basename: String, parsed: ParsedDoctest): String = {
-    s"""  "${escape(basename)}.scala:${parsed.lineNo}: ${parsed.symbol}" should {
+    s"""  "${escape(basename)}.scala:${parsed.lineNo}:${escape(parsed.symbol)}" should {
        |${parsed.components.map(gen(parsed.lineNo, _)).mkString("\n\n")}
        |  }""".stripMargin
   }

--- a/src/test/resources/Test.scala
+++ b/src/test/resources/Test.scala
@@ -18,4 +18,10 @@ class Test {
    * 2
    */
   def +=(x: Int) = x + x
+
+  /** Escape-character method
+   * scala> new Test() \ 1
+   * 2
+   */
+  def \(x: Int) = x + x
 }

--- a/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
@@ -29,7 +29,12 @@ object ScaladocExtractorSpec extends TestSuite {
             """/** Ascii method
               |   * scala> new Test() += 1
               |   * 2
-              |   */""".stripMargin, 16)
+              |   */""".stripMargin, 16),
+          ScaladocComment(None, "\\",
+            """/** Escape-character method
+              |   * scala> new Test() \ 1
+              |   * 2
+              |   */""".stripMargin, 22)
         )
       assert(expected == actual)
     }


### PR DESCRIPTION
Support for symbol names that include the Java String escape character `\`. These are no properly escaped out so they can be used in string test descriptions.

For example:

```scala
  // invalid
  include(new _root_.org.scalacheck.Properties("\") {
```

Is now written as:

```scala
  // valid
  include(new _root_.org.scalacheck.Properties("\\") {
```