### PR TITLE
Scalameta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jdk: oraclejdk8
 
 matrix:
   include:
-  - env: SBT_VERSION="0.13.17"
-    scala: 2.10.7
   - env: SBT_VERSION="1.1.6"
     scala: 2.12.6
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you are using [``Specs2``](https://github.com/etorreborre/specs2), add the fo
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core"       % "3.10.0" % Test,
-  "org.specs2" %% "specs2-scalacheck" % "3.10.0" % Test
+  "org.specs2" %% "specs2-core"       % "4.3.2" % Test,
+  "org.specs2" %% "specs2-scalacheck" % "4.3.2" % Test
 )
 
 doctestTestFramework := DoctestTestFramework.Specs2

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,13 @@ val versions = new {
   val Minitest   = "2.1.1"
   val CommonsIO  = "2.6"
   val Lang3      = "3.7"
+  val ScalaMeta  = "3.7.4"
 }
 
 lazy val root = (project in file(".")).settings(
   sbtPlugin := true,
-  crossSbtVersions := Vector("0.13.17", "1.1.6"),
+  scalaVersion := "2.12.6",
+  crossSbtVersions := Vector("1.1.6"),
   organization := "com.github.tkawachi",
   name := "sbt-doctest",
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
@@ -25,15 +27,14 @@ lazy val root = (project in file(".")).settings(
     "-encoding", "UTF-8",
     "-feature",
     "-unchecked",
-    "-Xfatal-warnings"
-  ) ++ (if (scalaVersion.value startsWith "2.10.")
-          List("-Xlint", "-target:jvm-1.6")
-        else
-          List("-Xlint:-unused,_")),
+    "-Xfatal-warnings",
+    "-Xlint:-unused,_"
+  ),
   libraryDependencies ++= Seq(
-    "org.scala-lang"     %  "scala-compiler"      % scalaVersion.value,
     "commons-io"         %  "commons-io"          % versions.CommonsIO,
     "org.apache.commons" %  "commons-lang3"       % versions.Lang3,
+    "org.scalameta"      %% "scalameta"           % versions.ScalaMeta,
+    "org.scalameta"      %% "contrib"             % versions.ScalaMeta,
     "com.lihaoyi"        %% "utest"               % versions.utest        % Provided,
     "org.scalatest"      %% "scalatest"           % versions.ScalaTest    % Provided,
     "org.scalacheck"     %% "scalacheck"          % versions.ScalaCheck   % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val versions = new {
   val ScalaTest  = "3.0.5"
   val ScalaCheck = "1.14.0"
-  val Specs2     = "3.10.0"
+  val Specs2     = "4.3.2"
   val utest      = "0.6.4"
   val Minitest   = "2.1.1"
   val CommonsIO  = "2.6"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("org.scalariform"     % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"     % "0.3.4")

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,5 +1,3 @@
-ScriptedPlugin.scriptedSettings
-
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
   Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 }

--- a/src/main/scala-sbt-0.13/com/github/tkawachi/doctest/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/github/tkawachi/doctest/SbtCompat.scala
@@ -1,7 +1,0 @@
-package com.github.tkawachi.doctest
-
-import sbt.File
-
-object SbtCompat {
-  def toSource(file: File): File = file
-}

--- a/src/main/scala-sbt-1.0/com/github/tkawachi/doctest/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/com/github/tkawachi/doctest/SbtCompat.scala
@@ -1,9 +1,0 @@
-package com.github.tkawachi.doctest
-
-import sbt.File
-import sbt.internal.io.Source
-import sbt.io.{ AllPassFilter, NothingFilter }
-
-object SbtCompat {
-  def toSource(file: File): Source = new Source(file, AllPassFilter, NothingFilter)
-}

--- a/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala
@@ -4,8 +4,9 @@ import java.nio.file.Path
 import sbt._
 import Keys._
 import sbt.plugins.JvmPlugin
-import SbtCompat._
 import org.apache.commons.io.FilenameUtils
+import sbt.internal.io.Source
+import sbt.io.{ AllPassFilter, NothingFilter }
 
 /**
  * Sbt plugin for doctest.
@@ -145,7 +146,7 @@ object DoctestPlugin extends AutoPlugin {
     watchSources ++= {
       val pathFinder = doctestMarkdownPathFinder.value
       if (doctestMarkdownEnabled.value) {
-        pathFinder.get.map(toSource)
+        pathFinder.get.map(new Source(_, AllPassFilter, NothingFilter))
       } else {
         Seq.empty
       }

--- a/src/main/scala/com/github/tkawachi/doctest/ScaladocTestGenerator.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScaladocTestGenerator.scala
@@ -1,13 +1,12 @@
 package com.github.tkawachi.doctest
 
 import java.io.File
+
 import scala.io.Source
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.lang3.StringEscapeUtils.unescapeHtml4
 
 object ScaladocTestGenerator {
-
-  val extractor = new ScaladocExtractor
 
   private def decodeHtml(comment: ScaladocComment) = comment.copy(text = unescapeHtml4(comment.text))
 
@@ -17,11 +16,8 @@ object ScaladocTestGenerator {
   def apply(srcFile: File, srcEncoding: String, testGen: TestGen, decodeHtmlEnabled: Boolean): Seq[TestSource] = {
     val src = Source.fromFile(srcFile, srcEncoding).mkString
     val basename = FilenameUtils.getBaseName(srcFile.getName)
-    extractor.extract(src)
-      .map { comment =>
-        if (decodeHtmlEnabled) decodeHtml(comment)
-        else comment
-      }
+    ScaladocExtractor.extract(src)
+      .map(comment => if (decodeHtmlEnabled) decodeHtml(comment) else comment)
       .flatMap(comment => CommentParser(comment).right.toOption.filter(_.components.nonEmpty))
       .groupBy(_.pkg).map {
         case (pkg, examples) =>
@@ -30,9 +26,8 @@ object ScaladocTestGenerator {
       .toSeq
   }
 
-  def findEncoding(scalacOptions: Seq[String]): Option[String] = {
-    val index = scalacOptions.indexOf("-encoding")
-    // The next element of "-encoding"
-    if (index < 0 || index + 1 > scalacOptions.size - 1) None else Some(scalacOptions(index + 1))
+  def findEncoding(scalacOptions: Seq[String]): Option[String] = scalacOptions match {
+    case Seq() => None
+    case Seq(_, tail @ _*) => scalacOptions.zip(tail).collectFirst { case ("-encoding", enc) => enc }
   }
 }

--- a/src/sbt-test/sbt-doctest/html-entities/build.sbt
+++ b/src/sbt-test/sbt-doctest/html-entities/build.sbt
@@ -21,11 +21,20 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"    %% "utest"             % "0.6.4"  % Test,
   "org.scalatest"  %% "scalatest"         % "3.0.5"  % Test,
   "org.scalacheck" %% "scalacheck"        % "1.14.0" % Test,
-  "org.specs2"     %% "specs2-core"       % "3.10.0"  % Test,
-  "org.specs2"     %% "specs2-scalacheck" % "3.10.0"  % Test,
   "io.monix"       %% "minitest"          % "2.1.1"  % Test,
   "io.monix"       %% "minitest-laws"     % "2.1.1"  % Test
-)
+) ++ (
+  if (scalaVersion.value.startsWith("2.10"))
+    Seq(
+      "org.specs2"     %% "specs2-core"       % "3.10.0"  % Test,
+      "org.specs2"     %% "specs2-scalacheck" % "3.10.0"  % Test
+    )
+  else
+    Seq(
+      "org.specs2"     %% "specs2-core"       % "4.3.2"  % Test,
+      "org.specs2"     %% "specs2-scalacheck" % "4.3.2"  % Test,
+    )
+  )
 
 testFrameworks += new TestFramework("minitest.runner.Framework")
 

--- a/src/sbt-test/sbt-doctest/simple/build.sbt
+++ b/src/sbt-test/sbt-doctest/simple/build.sbt
@@ -25,11 +25,21 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"    %% "utest"             % "0.6.4"  % Test,
   "org.scalatest"  %% "scalatest"         % "3.0.5"  % Test,
   "org.scalacheck" %% "scalacheck"        % "1.14.0" % Test,
-  "org.specs2"     %% "specs2-core"       % "3.10.0"  % Test,
-  "org.specs2"     %% "specs2-scalacheck" % "3.10.0"  % Test,
   "io.monix"       %% "minitest"          % "2.1.1"  % Test,
   "io.monix"       %% "minitest-laws"     % "2.1.1"  % Test
-)
+) ++ (
+  if (scalaVersion.value.startsWith("2.10"))
+    Seq(
+      "org.specs2"     %% "specs2-core"       % "3.10.0"  % Test,
+      "org.specs2"     %% "specs2-scalacheck" % "3.10.0"  % Test
+    )
+  else
+    Seq(
+      "org.specs2"     %% "specs2-core"       % "4.3.2"  % Test,
+      "org.specs2"     %% "specs2-scalacheck" % "4.3.2"  % Test,
+    )
+  )
+
 
 doctestMarkdownEnabled    := true
 doctestMarkdownPathFinder := baseDirectory.value ** "*.md"

--- a/src/test/resources/Test.scala
+++ b/src/test/resources/Test.scala
@@ -18,4 +18,14 @@ class Test {
    * 2
    */
   def +=(x: Int) = x + x
+
+  /**
+    * Doc on val
+    */
+  val x = 23
+
+  /**
+    * Doc on var
+    */
+  var z = "zzz"
 }

--- a/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/ScaladocExtractorSpec.scala
@@ -7,11 +7,12 @@ object ScaladocExtractorSpec extends TestSuite {
 
   val tests = this{
 
-    val extractor = new ScaladocExtractor
+    import ScaladocExtractor.extract
+
+    def extractFromFile(path: String) = extract(Source.fromFile(path).mkString)
 
     "extracts from Test.scala" - {
-      val src = Source.fromFile("src/test/resources/Test.scala").mkString
-      val actual = extractor.extract(src)
+      val actual = extractFromFile("src/test/resources/Test.scala")
       val expected =
         List(
           ScaladocComment(None, "Test", "/**\n * Test class\n */", 1),
@@ -29,13 +30,20 @@ object ScaladocExtractorSpec extends TestSuite {
             """/** Ascii method
               |   * scala> new Test() += 1
               |   * 2
-              |   */""".stripMargin, 16))
+              |   */""".stripMargin, 16),
+          ScaladocComment(None, "x",
+            """/**
+              |    * Doc on val
+              |    */""".stripMargin, 22),
+          ScaladocComment(None, "z",
+            """/**
+              |    * Doc on var
+              |    */""".stripMargin, 27))
       assert(expected == actual)
     }
 
     "extracts from RootPackage.scala" - {
-      val src = Source.fromFile("src/test/resources/RootPackage.scala").mkString
-      val actual = extractor.extract(src)
+      val actual = extractFromFile("src/test/resources/RootPackage.scala")
       val expected =
         List(
           ScaladocComment(None, "Root1", "/** Class comment */", 1),
@@ -49,8 +57,7 @@ object ScaladocExtractorSpec extends TestSuite {
     }
 
     "extracts from Package.scala" - {
-      val src = Source.fromFile("src/test/resources/Package.scala").mkString
-      val actual = extractor.extract(src)
+      val actual = extractFromFile("src/test/resources/Package.scala")
       val expected =
         List(
           ScaladocComment(Some("some.pkg"), "Root1", "/** Class comment */", 3),
@@ -58,6 +65,67 @@ object ScaladocExtractorSpec extends TestSuite {
           ScaladocComment(Some("some.pkg.a1"), "A1", "/** A1 */", 10),
           ScaladocComment(Some("some.pkg.a1.b1"), "B1", "/** B1 */", 13),
           ScaladocComment(Some("some.pkg"), "Root2", "/** Root2 */", 18))
+      assert(expected == actual)
+    }
+
+    "extracts only Scaladocs with some parseable text" - {
+      val source =
+        """
+          |package all_scaladocs_without_code
+          |
+          |/**
+          | * @version 123
+          | * @since 1953
+          | */
+          |class GotNothing {
+          |
+          |  /**
+          |
+          |  */
+          |  val a = 0
+          |
+          |  /**
+          |   *
+          |   */
+          |  var b = 0
+          |
+          |  /**
+          |   */
+          |  def c = 0
+          |
+          |  /**
+          |  *
+          |  *
+          |  *
+          |  */
+          |  def d = 0
+          |
+          |  /**
+          |   * @param i an Int
+          |   * @returns an Int
+          |   */
+          |  def e(i: Int) = 0
+          |
+          |  /**
+          |   * @deprecated for ever
+          |   */
+          |  def f = 0
+          |
+          |  /**
+          |   * @todo write code example like
+          |   *    require(g == 0)
+          |   */
+          |  def g = 0
+          |
+          |  /**
+          |  * @constructor
+          |  */
+          |  def this(i: Int) = this()
+          |}
+        """.stripMargin
+
+      val actual = extract(source)
+      val expected = Nil
       assert(expected == actual)
     }
 

--- a/src/test/scala/com/github/tkawachi/doctest/ScaladocTestGeneratorSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/ScaladocTestGeneratorSpec.scala
@@ -1,0 +1,27 @@
+package com.github.tkawachi.doctest
+
+import utest._
+
+object ScaladocTestGeneratorSpec extends TestSuite {
+
+  import ScaladocTestGenerator.findEncoding
+
+  val tests = this{
+
+    "findEncoding should work" - {
+      assert(
+        findEncoding(Nil).isEmpty,
+        findEncoding(Seq("x")).isEmpty,
+        findEncoding(Seq("x", "y")).isEmpty,
+        findEncoding(Seq("-encoding")).isEmpty,
+        findEncoding(Seq("x", "-encoding")).isEmpty,
+        findEncoding(Seq("x", "y", "-encoding")).isEmpty)
+
+      assert(
+        findEncoding(Seq("-encoding", "utf-8")).contains("utf-8"),
+        findEncoding(Seq("-encoding", "utf-8", "x")).contains("utf-8"),
+        findEncoding(Seq("-encoding", "utf-8", "x", "y")).contains("utf-8"))
+    }
+
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
2 different commits (can do two different PRs if needed):
1. replaces nsc with scalameta for Scaladoc extraction. it also drops support for sbt 0.13.x, as scalameta is not available for scala 2.10
2. bumps specs2 to latest 4.x version

closes #6 

@tkawachi please review

I've locally tested new version on cats and new (0.9.0-SNAPSHOT) and old (0.8.0) version produce same results
I can test it on other oss projects locally to make sure it's fully compatible if needed
