### PR TITLE
Parse annotations as verbatim strings

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/CommentParser.scala
@@ -60,10 +60,11 @@ trait GenericParser extends RegexParsers {
     }
 
   private val verbatimBegin = {
+    val annotation = ("@" ~ anyStr1) ^^ append
     val keywords = "abstract" | "case" | "class" | "def" | "implicit" | "import" |
       "lazy" | "object" | "sealed" | "trait" | "type" | "val" | "var"
     val whiteSpacePlusAnyStr = horizontalWhiteSpace ~ anyStr ^^ append
-    keywords ~ (whiteSpacePlusAnyStr | emptyStr) ^^ PositionedString.compose(append)
+    (annotation | keywords) ~ (whiteSpacePlusAnyStr | emptyStr) ^^ PositionedString.compose(append)
   }
 
   def verbatim(prompt: Prompt): Parser[Verbatim] =

--- a/src/sbt-test/sbt-doctest/simple/src/main/scala/VerbatimTest.scala
+++ b/src/sbt-test/sbt-doctest/simple/src/main/scala/VerbatimTest.scala
@@ -69,4 +69,11 @@ object VerbatimTest {
    * res0: Int = 4
    */
   type MyInt = Int
+
+  /**
+    * scala> @deprecated("a", "b") case class Foo(x: Int)
+    * scala> Foo(1)
+    * res0: Foo = Foo(1)
+    */
+  case class Foo(x: Int)
 }

--- a/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/CommentParserSpec.scala
@@ -355,6 +355,15 @@ object CommentParserSpec extends TestSuite {
         assert(expected == actual)
       }
 
+      "parses class definitions with annotations" - {
+        val comment =
+          """ * scala> @deprecated("foo", "bar") case class Foo(x: Int)
+          """.stripMargin
+        val actual = parse(comment).get
+        val expected = List(Verbatim("@deprecated(\"foo\", \"bar\") case class Foo(x: Int)"))
+        assert(expected == actual)
+      }
+
       "parses an example that starts with a verbatim keyword" - {
         val comment =
           """ * scala> val value = 1


### PR DESCRIPTION
This way things like

```scala
scala> @MyAnnotation case class Foo(x: Int)
```

get properly translated as verbatim lines, otherwise they would have
been ignored.