### PR TITLE
Update ScalaTest 3.1 Matchers to use relocated package name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" test scripted
 
-jdk: oraclejdk8
+jdk: openjdk8
 
 matrix:
   include:

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTest30Gen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTest30Gen.scala
@@ -7,4 +7,6 @@ object ScalaTest30Gen extends ScalaTestGen {
   override protected def withCheckersString: String = "with _root_.org.scalatest.prop.Checkers"
 
   override protected def funSpecClass: String = "_root_.org.scalatest.FunSpec"
+
+  override protected def matchersClass: String = "_root_.org.scalatest.Matchers"
 }

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTest31Gen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTest31Gen.scala
@@ -7,4 +7,6 @@ object ScalaTest31Gen extends ScalaTestGen {
   override protected def withCheckersString: String = "with _root_.org.scalatestplus.scalacheck.Checkers"
 
   override protected def funSpecClass: String = "_root_.org.scalatest.funspec.AnyFunSpec"
+
+  override protected def matchersClass: String = "_root_.org.scalatest.matchers.should.Matchers"
 }

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -17,10 +17,9 @@ trait ScalaTestGen extends TestGen {
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String = {
     val withCheckers: String = if (containsProperty(parsedList)) withCheckersString else ""
 
-    val st = "_root_.org.scalatest"
     s"""class ${basename}Doctest
        |    extends $funSpecClass
-       |    with $st.Matchers
+       |    with $matchersClass
        |    $withCheckers""".stripMargin
   }
 
@@ -48,6 +47,8 @@ trait ScalaTestGen extends TestGen {
   protected def withCheckersString: String
 
   protected def funSpecClass: String
+
+  protected def matchersClass: String
 }
 
 object ScalaTestGen {

--- a/src/sbt-test/sbt-doctest/scalatest31/build.sbt
+++ b/src/sbt-test/sbt-doctest/scalatest31/build.sbt
@@ -6,9 +6,9 @@ crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 // Declares scalatest, scalacheck dependencies explicitly.
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.1.0-SNAP12" % "test",
-  "org.scalatestplus" %% "scalatestplus-scalacheck" % "1.0.0-SNAP7" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.1.0" % "test",
+  "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
 )
 
 doctestTestFramework := DoctestTestFramework.ScalaTest

--- a/src/sbt-test/sbt-doctest/scalatest31/test
+++ b/src/sbt-test/sbt-doctest/scalatest31/test
@@ -6,3 +6,6 @@ $ exists target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
 $ exists target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala
 > existsInFile "with _root_.org.scalatestplus.scalacheck.Checkers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
 > existsInFile "with _root_.org.scalatestplus.scalacheck.Checkers" target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala
+
+> existsInFile "with _root_.org.scalatest.matchers.should.Matchers" target/scala-2.11/src_managed/test/sbt_doctest/MainDoctest.scala
+> existsInFile "with _root_.org.scalatest.matchers.should.Matchers" target/scala-2.12/src_managed/test/sbt_doctest/MainDoctest.scala

--- a/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
@@ -127,7 +127,7 @@ object TestGenSpec extends TestSuite {
             |
             |class MyClassDoctest
             |    extends _root_.org.scalatest.funspec.AnyFunSpec
-            |    with _root_.org.scalatest.Matchers
+            |    with _root_.org.scalatest.matchers.should.Matchers
             |    with _root_.org.scalatestplus.scalacheck.Checkers {
             |
             |  def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = {


### PR DESCRIPTION
In addition to the changes handled by #131, ScalaTest 3.1 also moved where the `Matchers` trait is located; it used to be `org.scalatest.Matchers` but is now at `org.scalatest.matchers.should.Matchers`. (Using the old location results in deprecation warnings.)