### PR TITLE
Only import propBoolean from Prop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" test scripted
 
-jdk: oraclejdk8
+jdk: openjdk8
 
 matrix:
   include:

--- a/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
@@ -15,7 +15,7 @@ object MinitestGen extends TestGen {
        |${
       if (TestGen.containsProperty(parsedList))
         s"""import _root_.minitest.laws.Checkers
-           |import _root_.org.scalacheck.Prop._
+           |import _root_.org.scalacheck.Prop.propBoolean
            |${TestGen.importArbitrary(parsedList)}""".stripMargin
       else ""
     }""".stripMargin

--- a/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
@@ -15,7 +15,7 @@ object MinitestGen extends TestGen {
        |${
       if (TestGen.containsProperty(parsedList))
         s"""import _root_.minitest.laws.Checkers
-           |import _root_.org.scalacheck.Prop.propBoolean
+           |import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}
            |${TestGen.importArbitrary(parsedList)}""".stripMargin
       else ""
     }""".stripMargin

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -12,7 +12,7 @@ object ScalaCheckGen extends TestGen {
   override protected def importsLine(parsedList: Seq[ParsedDoctest]): String = {
     val importProp =
       if (TestGen.containsExample(parsedList) || TestGen.containsProperty(parsedList))
-        "import _root_.org.scalacheck.Prop.propBoolean"
+        "import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}"
       else
         ""
     s"""${TestGen.importArbitrary(parsedList)}

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -12,7 +12,7 @@ object ScalaCheckGen extends TestGen {
   override protected def importsLine(parsedList: Seq[ParsedDoctest]): String = {
     val importProp =
       if (TestGen.containsExample(parsedList) || TestGen.containsProperty(parsedList))
-        "import _root_.org.scalacheck.Prop._"
+        "import _root_.org.scalacheck.Prop.propBoolean"
       else
         ""
     s"""${TestGen.importArbitrary(parsedList)}

--- a/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
@@ -221,7 +221,7 @@ object TestGenSpec extends TestSuite {
           """package com.example.tests
             |
             |import _root_.org.scalacheck.Arbitrary._
-            |import _root_.org.scalacheck.Prop._
+            |import _root_.org.scalacheck.Prop.propBoolean
             |
             |object MyClassDoctest
             |    extends _root_.org.scalacheck.Properties("MyClass.scala") {
@@ -270,7 +270,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.minitest._
             |import _root_.minitest.laws.Checkers
-            |import _root_.org.scalacheck.Prop._
+            |import _root_.org.scalacheck.Prop.propBoolean
             |import _root_.org.scalacheck.Arbitrary._
             |
             |object MyClassDoctest extends SimpleTestSuite with Checkers {

--- a/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
@@ -221,7 +221,7 @@ object TestGenSpec extends TestSuite {
           """package com.example.tests
             |
             |import _root_.org.scalacheck.Arbitrary._
-            |import _root_.org.scalacheck.Prop.propBoolean
+            |import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}
             |
             |object MyClassDoctest
             |    extends _root_.org.scalacheck.Properties("MyClass.scala") {
@@ -270,7 +270,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.minitest._
             |import _root_.minitest.laws.Checkers
-            |import _root_.org.scalacheck.Prop.propBoolean
+            |import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}
             |import _root_.org.scalacheck.Arbitrary._
             |
             |object MyClassDoctest extends SimpleTestSuite with Checkers {


### PR DESCRIPTION
I noticed this because of a [change in Dotty that I think is a bug](https://github.com/lampepfl/dotty/issues/8047), but I think it's the right thing to do anyway, since importing `Prop._`  brings in a lot of other definitions that aren't needed.