### PR TITLE
Backtick generated doctest class names

### DIFF
--- a/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MicroTestGen.scala
@@ -9,7 +9,7 @@ object MicroTestGen extends TestGen {
     "import _root_.utest._"
 
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String =
-    s"object ${basename}Doctest extends TestSuite"
+    s"object `${basename}Doctest` extends TestSuite"
 
   override protected def testCasesLine(basename: String, parsedList: Seq[ParsedDoctest]): String =
     s"""

--- a/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MinitestGen.scala
@@ -7,7 +7,7 @@ object MinitestGen extends TestGen {
 
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String = {
     val withCheckers = if (TestGen.containsProperty(parsedList)) "with Checkers" else ""
-    s"object ${basename}Doctest extends SimpleTestSuite $withCheckers"
+    s"object `${basename}Doctest` extends SimpleTestSuite $withCheckers"
   }
 
   override protected def importsLine(parsedList: Seq[ParsedDoctest]): String =

--- a/src/main/scala/com/github/tkawachi/doctest/MunitGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/MunitGen.scala
@@ -8,8 +8,8 @@ object MunitGen extends TestGen {
   } else "import _root_.munit._"
 
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String =
-    if (TestGen.containsProperty(parsedList)) s"class ${basename}Doctest extends ScalaCheckSuite"
-    else s"class ${basename}Doctest extends FunSuite"
+    if (TestGen.containsProperty(parsedList)) s"class `${basename}Doctest` extends ScalaCheckSuite"
+    else s"class `${basename}Doctest` extends FunSuite"
 
   override protected def generateTestCase(caseName: String, caseBody: String): String = {
     s"""  test("$caseName") {

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaCheckGen.scala
@@ -5,7 +5,7 @@ import com.github.tkawachi.doctest.StringUtil.escape
 object ScalaCheckGen extends TestGen {
 
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String = {
-    s"""object ${basename}Doctest
+    s"""object `${basename}Doctest`
        |    extends _root_.org.scalacheck.Properties("${escape(basename)}.scala")""".stripMargin
   }
 

--- a/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/ScalaTestGen.scala
@@ -13,7 +13,7 @@ trait ScalaTestGen extends TestGen {
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String = {
     val withCheckers: String = if (containsProperty(parsedList)) withCheckersString else ""
 
-    s"""class ${basename}Doctest
+    s"""class `${basename}Doctest`
        |    extends $funSpecClass
        |    $withCheckers""".stripMargin
   }

--- a/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
+++ b/src/main/scala/com/github/tkawachi/doctest/Specs2TestGen.scala
@@ -11,7 +11,7 @@ object Specs2TestGen extends TestGen {
     TestGen.importArbitrary(parsedList)
 
   override protected def suiteDeclarationLine(basename: String, parsedList: Seq[ParsedDoctest]): String = {
-    s"""class ${basename}Doctest
+    s"""class `${basename}Doctest`
        |    extends $BasePackage.mutable.Specification
        |    with $BasePackage.ScalaCheck""".stripMargin
   }

--- a/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
+++ b/src/test/scala/com/github/tkawachi/doctest/TestGenSpec.scala
@@ -28,7 +28,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.utest._
             |
-            |object MyClassDoctest extends TestSuite {
+            |object `MyClassDoctest` extends TestSuite {
             |
             |  def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = {
             |    val _ = () => (a1, a2)
@@ -76,7 +76,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.org.scalacheck.Arbitrary._
             |
-            |class MyClassDoctest
+            |class `MyClassDoctest`
             |    extends _root_.org.scalatest.FunSpec
             |    with _root_.org.scalatest.prop.Checkers {
             |
@@ -124,7 +124,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.org.scalacheck.Arbitrary._
             |
-            |class MyClassDoctest
+            |class `MyClassDoctest`
             |    extends _root_.org.scalatest.funspec.AnyFunSpec
             |    with _root_.org.scalatestplus.scalacheck.Checkers {
             |
@@ -172,7 +172,7 @@ object TestGenSpec extends TestSuite {
             |
             |import _root_.org.scalacheck.Arbitrary._
             |
-            |class MyClassDoctest
+            |class `MyClassDoctest`
             |    extends _root_.org.specs2.mutable.Specification
             |    with _root_.org.specs2.ScalaCheck {
             |
@@ -221,7 +221,7 @@ object TestGenSpec extends TestSuite {
             |import _root_.org.scalacheck.Arbitrary._
             |import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}
             |
-            |object MyClassDoctest
+            |object `MyClassDoctest`
             |    extends _root_.org.scalacheck.Properties("MyClass.scala") {
             |
             |  def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = {
@@ -271,7 +271,7 @@ object TestGenSpec extends TestSuite {
             |import _root_.org.scalacheck.Prop.{BooleanOperators => _, _}
             |import _root_.org.scalacheck.Arbitrary._
             |
-            |object MyClassDoctest extends SimpleTestSuite with Checkers {
+            |object `MyClassDoctest` extends SimpleTestSuite with Checkers {
             |
             |  def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = {
             |    val _ = () => (a1, a2)
@@ -316,7 +316,7 @@ object TestGenSpec extends TestSuite {
                              |import _root_.org.scalacheck.Prop._
                              |
                              |
-                             |class MyClassDoctest extends ScalaCheckSuite {
+                             |class `MyClassDoctest` extends ScalaCheckSuite {
                              |
                              |  def sbtDoctestTypeEquals[A](a1: => A)(a2: => A): _root_.scala.Unit = {
                              |    val _ = () => (a1, a2)


### PR DESCRIPTION
Fixes #300.  Instead of detecting whether the basename is part of a valid identifier, we just unconditionally backtick the classname.